### PR TITLE
Support building with GHC 9.2

### DIFF
--- a/src/Language/JVM/Parser.hs
+++ b/src/Language/JVM/Parser.hs
@@ -120,7 +120,7 @@ import Data.Array (Array, (!), listArray)
 import Data.Binary
 import Data.Binary.Get
 import Data.Binary.IEEE754
-import Data.Bits
+import Data.Bits (Bits(..))
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as L
 import Data.Char

--- a/src/Language/JVM/Parser.hs
+++ b/src/Language/JVM/Parser.hs
@@ -128,6 +128,7 @@ import Data.Int
 import Data.List
 import Data.Map (Map)
 import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
 import Prelude hiding(read)
 import System.IO
 
@@ -234,7 +235,8 @@ makeMethodKey :: String -- ^ Method name
               -> String -- ^ Method descriptor
               -> MethodKey
 makeMethodKey name descriptor = MethodKey name parameters returnType
-  where Just (returnType, parameters) = parseMethodDescriptor descriptor
+  where (returnType, parameters) =
+          fromMaybe (error "Invalid method descriptor") $ parseMethodDescriptor descriptor
 
 mainKey :: MethodKey
 mainKey = makeMethodKey "main" "([Ljava/lang/String;)V"


### PR DESCRIPTION
`base-4.16.*` adds an `Ior` newtype to `Data.Bits` to represent bitwise inclusive OR. This clashes with the `Ior` data constructor used in `Language.JVM.Parser`, however:

```
[3 of 4] Compiling Language.JVM.Parser ( src/Language/JVM/Parser.hs, interpreted )

src/Language/JVM/Parser.hs:601:20: error:
    Ambiguous occurrence ‘Ior’
    It could refer to
       either ‘Data.Bits.Ior’,
              imported from ‘Data.Bits’ at src/Language/JVM/Parser.hs:123:1-16
           or ‘Language.JVM.Common.Ior’,
              imported from ‘Language.JVM.Common’ at src/Language/JVM/Parser.hs:135:1-26
              (and originally defined at src/Language/JVM/Common.hs:310:5-7)
    |
601 |     0x80 -> return Ior
    |                    ^^^
```

Thankfully, the fix is simple: use an explicit import from `Data.Bits` to only import the `Bits` class and nothing else.

Also, GHC 9.2 now includes `-Wincomplete-uni-patterns` as a part of `-Wall`, which causes `Language.JVM.{CFG,Parser}` to produce warnings when built with 9.2. To fix the warnings, I turned each partial uni-pattern into a `case` with an explicit call to `error` if the pattern fails to match. This is no less partial than before, but it avoids warnings and will produce a more specific error message if the pattern fails to match.