### PR TITLE
Remove `data-binary-ieee754` dependency in favor of `binary`

### DIFF
--- a/jvm-parser.cabal
+++ b/jvm-parser.cabal
@@ -31,7 +31,6 @@ Library
                        binary,
                        bytestring,
                        containers,
-                       data-binary-ieee754,
                        fgl,
                        fingertree,
                        prettyprinter >= 1.7.0,

--- a/src/Language/JVM/Parser.hs
+++ b/src/Language/JVM/Parser.hs
@@ -119,7 +119,6 @@ import Control.Monad
 import Data.Array (Array, (!), listArray)
 import Data.Binary
 import Data.Binary.Get
-import Data.Binary.IEEE754
 import Data.Bits (Bits(..))
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as L
@@ -306,13 +305,13 @@ getConstantPoolInfo = do
     3 -> do val <- get
             return [ConstantInteger val]
     ---- CONSTANT_Float
-    4  -> do v <- getFloat32be
+    4  -> do v <- getFloatbe
              return [ConstantFloat v]
     ---- CONSTANT_Long
     5  -> do val <- get
              return [Phantom, ConstantLong val]
     ---- CONSTANT_Double
-    6  -> do val <- getFloat64be
+    6  -> do val <- getDoublebe
              return [Phantom, ConstantDouble val]
     ---- CONSTANT_Class
     7  -> do index <- getWord16be


### PR DESCRIPTION
The `data-binary-ieee754` library, which `jvm-parser` depends on, is deprecated. Fortunately, `binary` offers the same functionality that `jvm-parser` uses, so switching to `binary` proves straightforward.